### PR TITLE
Bugfix: increase timeout

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -58,7 +58,7 @@ Parameters:
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 30
+    Timeout: 45
 
 Resources:
 #lambda execution role config


### PR DESCRIPTION
Running the lambda without recipient restrictions has increased the time it takes to calculate the data structure from 10s to 25s, leaving us with insufficient time to send the emails. Increase timeout by 15s.
