### PR TITLE
[IT-3506] Address lambda timeout issue from 2024-03-02

### DIFF
--- a/email_totals/ce.py
+++ b/email_totals/ce.py
@@ -2,13 +2,21 @@ import logging
 from datetime import datetime, timedelta
 
 import boto3
+from botocore.config import Config as BotoConfig
+
 
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG)
 
-ce_client = boto3.client('ce')
-
 cost_metric = 'NetAmortizedCost'
+
+# Use adaptive mode in an attempt to optimize retry back-off
+ce_config = BotoConfig(
+    retries = {
+        'mode': 'adaptive',  # default mode is legacy
+    }
+)
+ce_client = boto3.client('ce', config=ce_config)
 
 # get_cost_and_usage_with_resources() can only look back at most 14 days,
 # but we only need current resources missing tags, so hard-code the period

--- a/email_totals/ses.py
+++ b/email_totals/ses.py
@@ -462,11 +462,6 @@ def send_email(recipients, subject, body_html, body_text):
             Source=sender,
         )
 
-        # We need to rate limit our calls to 'send_email', our current SES
-        # quota allows for sending 14 emails per second, sleep for 72ms after
-        # each call to send a maximum of 14 emails in 1008ms.
-        time.sleep(0.072)
-
     # Display an error if something goes wrong.
     except ClientError as e:
         LOG.exception(e)

--- a/template.yaml
+++ b/template.yaml
@@ -63,7 +63,7 @@ Parameters:
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 60
+    Timeout: 120
 
 Resources:
 #lambda execution role config


### PR DESCRIPTION
The lambda run on 2024-03-02 ran approximately twice as slow as the run on 2024-02-02 (and encountered a timeout while collecting data), but the manual run on 2024-03-03 was in between the other two and only took a couple seconds longer than the 60-second timeout.

* Double the timeout from 60 seconds to 120 seconds due to variable processing time across lambda environments.
* Rely on boto retries instead of sleeping between SES calls.
* Use adaptive retries for CE calls to optimize retry backoff.
