### PR TITLE
[IT-3553] bugfix: check for empty resources dict

### DIFF
--- a/email_totals/app.py
+++ b/email_totals/app.py
@@ -120,6 +120,7 @@ def get_resource_totals(target_period, compare_period, minimum_total):
                 # If this account is already listed, the email is a duplicate
                 # this can happen if it is tagged with different casing.
                 if account_id in resources[email]['resources']:
+                    LOG.debug(f"duplicate entry found")
                     resources[email]['resources'][account_id]['total'] += amount
                 else:
                     resources[email]['resources'][account_id] = {'total': amount}
@@ -286,7 +287,9 @@ def get_account_totals(target_period, compare_period, minimum_total):
                 pct_change = (target_total / compare_total) - 1
                 account_dict['accounts'][account]['change'] = pct_change
 
-        output[owner] = account_dict
+        # Only add the subkey for the owner if its not empty
+        if account_dict['accounts']:
+            output[owner] = account_dict
 
     return output, account_names
 

--- a/email_totals/ses.py
+++ b/email_totals/ses.py
@@ -171,7 +171,7 @@ def build_usage_table(usage, account_names, total=None, html=False):
 
         else:
             _td = [account_name, account_id, total, change]
-            output = '\t'.join(_td) + '\n'
+            output += '\t'.join(_td) + '\n'
 
     if html:
         output += "</table><br/>"
@@ -266,13 +266,13 @@ def build_user_email_body(summary, account_names):
         descr = ('You are tagged as owning resources in the following '
                  'accounts: ')
 
-        # Don't report the same account twice
+        # Don't report resources if we also own the account
         if account_usage is not None:
             for account_id in account_usage:
                 if account_id in resource_usage:
                     del resource_usage[account_id]
 
-        # Don't report empty usage
+        # Only generate output if we still have resource usage
         if resource_usage:
             output += build_paragraph(descr, html)
             output += build_usage_table(resource_usage, account_names, html=html)
@@ -324,8 +324,8 @@ def build_user_email_body(summary, account_names):
 
     text_body = f"{title}\n{intro}\n"
 
-    if 'resources' in summary:
-        if 'accounts' in summary:
+    if 'resources' in summary and summary['resources']:
+        if 'accounts' in summary and summary['accounts']:
             html_body += _build_resource_usage(summary['resources'],
                                                summary['accounts'],
                                                html=True)

--- a/email_totals/ses.py
+++ b/email_totals/ses.py
@@ -272,8 +272,10 @@ def build_user_email_body(summary, account_names):
                 if account_id in resource_usage:
                     del resource_usage[account_id]
 
-        output += build_paragraph(descr, html)
-        output += build_usage_table(resource_usage, account_names, html=html)
+        # Don't report empty usage
+        if resource_usage:
+            output += build_paragraph(descr, html)
+            output += build_usage_table(resource_usage, account_names, html=html)
 
         return output
 

--- a/tests/unit/test_org.py
+++ b/tests/unit/test_org.py
@@ -5,15 +5,18 @@ from email_totals import org
 
 def test_account_owners(mock_org_accounts,
                         mock_org_account_no_tags,
+                        mock_org_account_tags_user1,
+                        mock_org_account_tags_user2,
                         mock_org_account_tags_user3,
                         mock_org_account_tags_user4,
                         mock_org_account_owners):
     with Stubber(org.org_client) as _stub:
         _stub.add_response('list_accounts', mock_org_accounts)
 
-        # No owner tags for account1 or account2
+        # user1 owns account0; no one owns account1
+        _stub.add_response('list_tags_for_resource', mock_org_account_tags_user1)
         _stub.add_response('list_tags_for_resource', mock_org_account_no_tags)
-        _stub.add_response('list_tags_for_resource', mock_org_account_no_tags)
+        _stub.add_response('list_tags_for_resource', mock_org_account_tags_user2)
         _stub.add_response('list_tags_for_resource', mock_org_account_tags_user3)
         _stub.add_response('list_tags_for_resource', mock_org_account_tags_user4)
 


### PR DESCRIPTION
It's possible for an email to contain an empty table of owned resources
if all owned resources are in accounts also owned by the same email.

Only build a table for owned resources if there are still entries
left after removing owned accounts, and only include an `accounts`
subkey if account details have been found.

Adjust the test scenario accordingly, and add a description to it.